### PR TITLE
Fix some links and add more coverage of file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zinger
 
-Zinger is a receiver for [Zeek](https://www.zeek.org/) logs. It receives logs in any format
-supported by [zq](https://github.com/mccanne/zq/) and can store,
+`zinger` is a receiver for [Zeek](https://www.zeek.org/) logs. It receives logs in any format
+supported by [`zq`](https://github.com/brimsec/zq) and can store,
 process, and forward them to various outputs depending on its configuration.
 
 Currently supported outputs are:
@@ -19,12 +19,12 @@ and [go-avro](https://github.com/go-avro/avro) to construct
 schemas. It has native support for communicating with the Kafka
 [Schema Registry](https://github.com/confluentinc/schema-registry) and
 for transcoding
-[Zeek/Zng](https://github.com/mccanne/zq/blob/master/pkg/zng/docs/spec.md)
+[Zeek/ZNG](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md)
 into [Apache Avro](https://avro.apache.org/).
 
 ## Installation
 
-To install zinger, clone this repo and run `make install`:
+To install `zinger`, clone this repo and run `make install`:
 ```
 git clone https://github.com/brimsec/zinger.git
 cd zinger
@@ -46,12 +46,23 @@ The primary use case for zinger is to run it as a server that listens
 for incoming connections containing a stream of data in any format supported
 by zq, i.e., Zeek TSV streams, ZNG streams, NDJSON, etc.
 
-For example, when Zeek can be run with the
-[TSV streaming plugin](https://github.com/looky-cloud/zeek-tsv-http-plugin)
+For example, Zeek can be run with the
+[TSV streaming plugin](https://github.com/brimsec/zeek-tsv-http-plugin)
 configured to point at zinger and zinger will transcode all incoming data
-onto Kafka/Avro.
+onto the filesystem or Kafka/Avro.
 
 For example, running this command
+```
+zinger listen -f
+```
+
+starts up a process listening for incoming connections on the default port
+9890, which will then write a separate Zeek-format TSV log file for each
+incoming stream. When used with the TSV streaming plugin, the files produced
+should be equivalent to those Zeek typically writes to its `logs/current/`
+directory (`conn.log`, `dns.log`, etc.)
+
+Or, running this command
 ```
 zinger -k -b 192.168.1.1:9092 -r 192.168.1.1:8081 -t zeekdata -s zinger -n com.acme listen -l :6755
 ```
@@ -59,7 +70,11 @@ starts up a process to listen for incoming connections on port `6755` converting
 all such streams to Kafka/Avro streams by sending them as a Kafka producer to the
 Kafka service at `192.168.1.1:9092`.  The Schema Registry service at
 `192.168.1.1:8081` is used to create new schemas based on the incoming data.
-All newly created schemas are all created under the namespace `com.acme` under
+If a new schema needs to be created to handle the data in an incoming stream,
+it will be automatically created and stored in the Schema Registry.  If the schema
+already exists in the registry,
+the existing schemas will be used.
+All newly created schemas are created under the namespace `com.acme` under
 the subject `zinger`.
 Transcoded stream data is transmitted to Kafka on the topic `zeekdata`.
 
@@ -74,15 +89,13 @@ run this command on the same host where `zinger listen` is running:
 ```
 zinger post -a localhost:6755 conn.log
 ```
-This transmits the data in conn.log to zinger, which in turn, converts the data
-to Kafka/Avro and publishes it to the configured topic.  If a new schemas needs
-to be created to handle the data in conn.log, it will be automatically created
-and stored in the Schema Registry.  If the schema already exists in the registry,
-the existing schemas will be used.
+This transmits the data in conn.log to zinger, which in turn, will output it to
+the filesystem or Kafka/Avro based on the `listen` configs, such as those shown
+above.
 
 ### zinger ls
 
-To display the schemas in use, run
+To display the schemas in use with Kafka/Avro, run
 ```
 zinger ls
 ```
@@ -99,7 +112,7 @@ Here are a few caveats:
 to async to get decent performance.
 * Everything is written to a single topic.  It would be straightforward to add
 config to route data to different topics based on simple filter rules
-(we could use zql filtering logic and the zq filter proc).
+(we could use ZQL filtering logic and the zq filter processor).
 * Crash recoverable restart could be achieved by tying ZNG control acks
 to kafka message success so the Zeek TSV plugin would know where to restart.
 * Timestamps are converted to the logical microsecond timestamp documented


### PR DESCRIPTION
@henridf successfully brought over the file output option in https://github.com/brimsec/zinger/pull/7, but while verifying it I found there were a couple links in the README still pointing to old locations, and the README coverage was still almost exclusively focused on the Kafka/Avro use case. I've tried to bring some balance to it here by mentioning the file output option a bit more.